### PR TITLE
fix(audio): pre-open mic stream at startup to eliminate first-word latency

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -3,7 +3,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc, Arc, Mutex,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::stt::{LocalSttEngine, SttConfig, SttMode};
 use crate::transcribe::transcribe_with_cached_whisper;
@@ -275,6 +275,7 @@ pub fn close_audio_stream(
 pub fn do_start_recording(
     is_recording: &AtomicBool,
     mic_available: &AtomicBool,
+    reconnecting: &AtomicBool,
     sample_rate: &Mutex<Option<u32>>,
     buffer: &Arc<Mutex<Vec<f32>>>,
     is_recording_arc: &Arc<AtomicBool>,
@@ -291,8 +292,19 @@ pub fn do_start_recording(
         if stream_dead {
             tracing::warn!("Audio stream was dead, reconnecting before recording");
             mic_available.store(false, Ordering::SeqCst);
+        } else if reconnecting.load(Ordering::SeqCst) {
+            // A background reconnect (e.g. startup pre-open) is in progress.
+            // Wait for it instead of racing to open a second stream, which
+            // would leak the first cpal stream (same hazard as the BT path).
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while reconnecting.load(Ordering::SeqCst) && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
         }
-        try_reconnect_audio(mic_available, sample_rate, buffer, is_recording_arc, audio_thread, device_name.clone())?;
+        // Re-check: the background reconnect may have succeeded while we waited.
+        if !mic_available.load(Ordering::SeqCst) {
+            try_reconnect_audio(mic_available, sample_rate, buffer, is_recording_arc, audio_thread, device_name.clone())?;
+        }
         // Freshly reconnected stream is already on the correct device;
         // the mismatch check below will be a no-op.
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -803,6 +803,7 @@ pub fn start_recording(state: State<'_, AppState>) -> Result<(), String> {
     audio::do_start_recording(
         &state.is_recording,
         &state.mic_available,
+        &state.reconnecting,
         &state.sample_rate,
         &state.buffer,
         &state.is_recording,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,17 +922,17 @@ pub fn run() {
                 std::thread::spawn(move || cleanup_obsolete_models(&dir));
             }
 
-            // On-demand model: do NOT open the mic stream at startup.
-            // The stream is opened by do_start_recording on the first hotkey press.
-            // Opening CoreAudio at startup activates system DSP (echo-cancellation,
-            // noise-reduction) which alters system audio output — e.g. making
-            // background music louder — even when the user is not recording.
+            // The mic stream is pre-opened in a background thread shortly after
+            // startup (see below) so the first hotkey press has zero latency.
+            // Opening the stream activates CoreAudio DSP (echo-cancellation,
+            // noise-reduction), which is the accepted trade-off for zero first-word
+            // latency.  If pre-open fails, do_start_recording retries on the first
+            // hotkey press.
             let is_recording = Arc::new(AtomicBool::new(false));
             let buffer = Arc::new(Mutex::new(Vec::new()));
             let mic_available = false;
             let sample_rate: Option<u32> = None;
             let audio_thread_init: Option<audio::AudioThreadControl> = None;
-            tracing::info!("Mic stream deferred — will open on first recording (on-demand model)");
 
             let http_client = reqwest::blocking::Client::builder()
                 .timeout(std::time::Duration::from_secs(60))
@@ -1155,10 +1155,13 @@ pub fn run() {
             // try_reconnect_audio on the first press, blocking for ~100–300 ms
             // while CoreAudio initialises, causing the first words to be dropped.
             //
-            // Note: opening the stream activates CoreAudio DSP (noise reduction,
-            // echo cancellation) which can slightly alter system audio output.
-            // This is the same as the always-on behaviour before PR #20.
+            // `reconnecting` is set to true *before* spawning so that any hotkey
+            // press arriving in the first few hundred ms sees the flag and waits
+            // (via do_start_recording's spin-wait) instead of racing into
+            // spawn_audio_thread and leaking one cpal stream.
             {
+                let state = app.state::<AppState>();
+                state.reconnecting.store(true, Ordering::SeqCst);
                 let app_handle = app.handle().clone();
                 std::thread::spawn(move || {
                     let state = app_handle.state::<AppState>();
@@ -1174,6 +1177,8 @@ pub fn run() {
                         Ok(()) => tracing::info!("Mic stream pre-opened at startup"),
                         Err(e) => tracing::warn!("Mic pre-open failed (will retry on first hotkey): {}", e),
                     }
+                    // Release the guard so do_start_recording can proceed.
+                    state.reconnecting.store(false, Ordering::SeqCst);
                 });
             }
 
@@ -1467,6 +1472,7 @@ pub fn run() {
                                 match audio::do_start_recording(
                                     &state.is_recording,
                                     &state.mic_available,
+                                    &state.reconnecting,
                                     &state.sample_rate,
                                     &state.buffer,
                                     &state.is_recording,
@@ -1736,6 +1742,7 @@ fn start_meeting_mode(app: &AppHandle) {
     if let Err(e) = audio::do_start_recording(
         &state.is_recording,
         &state.mic_available,
+        &state.reconnecting,
         &state.sample_rate,
         &state.buffer,
         &state.is_recording,


### PR DESCRIPTION
## Problem

PR #20 changed the mic stream from always-on to on-demand: the stream is now opened on the first hotkey press instead of at app startup. This causes CoreAudio to initialise (~100–300 ms) while the user is already speaking after pressing the hotkey, silently dropping the first words of every new session.

Reproduction: restart the app → press hotkey → speak immediately → first syllable/word is missing from transcript.

## Root Cause

In `lib.rs`, `mic_available` starts as `false` and `audio_thread` as `None`. On the first hotkey press, `do_start_recording` calls `try_reconnect_audio` → `spawn_audio_thread`, which blocks until CoreAudio finishes hardware init. Only after that does `is_recording` flip to `true`.

## Fix

Spawn a background thread immediately after the model pre-warm block at startup that calls `try_reconnect_audio`. By the time the user presses the hotkey for the first time, the stream is already open and `do_start_recording` skips the reconnect, giving zero-latency start.

If pre-open fails (permission not yet granted, no mic device), the existing lazy-reconnect path in `do_start_recording` handles it gracefully — no behaviour change on error.

## Trade-offs

- Opening the stream at startup reactivates CoreAudio DSP (noise reduction, echo cancellation) — same side effect as before PR #20.
- The mic indicator in System Settings will show while the app is running (same as before PR #20).

## Test Plan

- [ ] Restart app → press hotkey → speak immediately → first word is captured
- [ ] Permissions denied on first launch → app still starts, first hotkey press triggers permission prompt as before
- [ ] Change mic device in Settings → stream reopens on next hotkey press as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)