### PR TITLE
fix(overlay): prevent state reset on macOS Space switch

### DIFF
--- a/frontend/src/overlay/App.svelte
+++ b/frontend/src/overlay/App.svelte
@@ -42,18 +42,22 @@
     | 'undo'
     | 'switching';
 
+  /** Terminal/short-lived phases where reset on hide is correct.
+   *  'undo' — context-specific; countdown expires intentionally on navigation.
+   *  Adding a new Phase without assigning it to TerminalPhase will cause a
+   *  type error on ACTIVE_PHASES, keeping the two lists in sync.
+   */
+  type TerminalPhase =
+    | 'preparing' | 'pasted' | 'copied' | 'error'
+    | 'edited' | 'edit_requires_polish' | 'meeting_stopped' | 'undo';
+
   /** Phases actively driven by backend events — do not reset on visibilitychange.
    *  Note: only 'switching' has a 30s safety timeout; the other active phases
    *  rely on the backend always emitting a terminal event. If the backend is
    *  killed mid-phase while the overlay is hidden, the next show may display a
    *  stale state (low risk — the backend emits 'preparing' before every hide).
-   *
-   *  Excluded (terminal/short-lived; reset on hide is correct):
-   *    'preparing', 'pasted', 'copied', 'error', 'edited',
-   *    'edit_requires_polish', 'meeting_stopped',
-   *    'undo' — context-specific; countdown expires intentionally on navigation
    */
-  const ACTIVE_PHASES: readonly Phase[] = [
+  const ACTIVE_PHASES: readonly Exclude<Phase, TerminalPhase>[] = [
     'recording', 'edit_recording', 'meeting_recording',
     'transcribing', 'polishing', 'processing',
     'switching', // model-switch in progress; backend owns the 'done' transition
@@ -471,7 +475,7 @@
       // During active recording/processing, state is driven by backend events.
       // macOS Space switches briefly fire visibilitychange — skip the reset
       // so we don't interrupt the current phase.
-      if (ACTIVE_PHASES.includes(phase)) {
+      if ((ACTIVE_PHASES as readonly Phase[]).includes(phase)) {
         return;
       }
       setPreparing();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,13 +241,16 @@ fn hide_overlay_delayed(app: &AppHandle, delay_ms: u64) {
 }
 
 /// Emit 'preparing' to reset overlay phase, then hide via delayed path.
-/// Uses `hide_overlay_delayed(0)` instead of `run_on_main_thread` so the
-/// Cocoa run loop yields before hiding, giving the WebView event loop a
-/// chance to process the IPC 'preparing' message first.
 fn reset_and_hide_overlay(app: &AppHandle) {
     if let Some(overlay) = app.get_webview_window("overlay") {
         let _ = overlay.emit("recording-status", "preparing");
     }
+    // Emit 'preparing' first so the WebView can process the phase reset before
+    // the window becomes invisible.  hide_overlay_delayed(0) schedules the
+    // actual hide on the main thread via a freshly spawned OS thread, which
+    // gives the run loop one extra iteration to deliver the IPC message.
+    // Ordering is best-effort: if the hide races ahead the stale phase is
+    // still corrected once the pending event is processed after the next show.
     hide_overlay_delayed(app, 0);
 }
 


### PR DESCRIPTION
## Summary

- Guard `handleVisibility()` in overlay to skip `setPreparing()` during active phases (recording, transcribing, polishing, etc.) — only reset on terminal states (pasted, copied, error)
- Add `NSWindowCollectionBehaviorStationary` (bit 16) to overlay window to reduce transient occlusion notifications during Space transition animations

## Root Cause

macOS fires `visibilitychange` events during full-screen Space switches. The overlay's `handleVisibility()` unconditionally called `setPreparing()` on `document.hidden`, resetting the recording state mid-recording.

## Test plan

- [ ] Start recording → switch Spaces (three-finger swipe) → verify overlay stays in "recording" state
- [ ] Start recording → switch to a full-screen app → verify overlay still shows "recording"
- [ ] Complete recording (pasted/copied state) → switch Spaces → verify stale state is properly cleaned up
- [ ] Verify meeting mode recording also unaffected by Space switches

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)